### PR TITLE
Update android.yml to avoid debug

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -26,7 +26,7 @@ jobs:
       working-directory: ./napkinapp
 
     - name: Build with Gradle
-      run: ./gradlew build
+      run: ./gradlew build -x lintDebug
       working-directory: ./napkinapp
 
     - name: Run Unit Tests


### PR DESCRIPTION
debug has literally nothing but an AndroidManifest to make the tests work, but this test tries to build it. This change will make it not try to build it.